### PR TITLE
[#5] 인트로 화면 추가 및 Claude Code 프로젝트 설정

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,34 @@
+현재 브랜치의 변경사항을 기반으로 GitHub Pull Request를 생성해줘.
+
+## 절차
+
+1. `git status`로 커밋되지 않은 변경사항이 있는지 확인해. 커밋되지 않은 변경이 있으면 사용자에게 먼저 커밋하라고 안내하고 중단해.
+2. `git log main..HEAD --oneline`으로 현재 브랜치의 커밋 목록을 확인해.
+3. `git diff main...HEAD`로 전체 변경 내용을 파악해.
+4. 브랜치 이름에서 이슈 번호를 추출해 (예: `feature/#4-navigation` → `#4`).
+5. 변경 내용을 분석하여 아래 PR 템플릿에 맞게 내용을 채워.
+6. 리모트에 푸시되지 않았다면 `git push -u origin <branch>` 로 푸시해.
+7. `gh pr create`로 PR을 생성해.
+
+## PR 템플릿
+
+```
+### What is this PR (Required)
+- **Issue Number** : close #<이슈번호>
+- 기타 관련 문서 :
+
+### Changes (Required)
+- <변경사항을 구체적으로 bullet point로 작성>
+
+### Review Point (Required)
+- <리뷰어가 주의 깊게 봐야 할 포인트를 작성>
+```
+
+## 규칙
+
+- PR 제목은 한국어로 작성하고, 70자 이내로 간결하게 작성해.
+- PR 제목 형식: `[#이슈번호] 변경 내용 요약` (예: `[#4] 바텀 네비게이션 도입 및 화면 구조 재설계`)
+- Changes 섹션은 커밋 메시지와 diff를 분석해서 구체적으로 작성해.
+- Review Point는 구조적 변경, 새로운 패턴 도입 등 리뷰어가 집중해야 할 부분을 작성해.
+- Screenshot 섹션은 생략해.
+- 마지막에 PR URL을 출력해줘.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:api.github.com)",
+      "Bash(git remote get-url origin)",
+      "Bash(find /Users/yuhohyeon/Desktop/project/LinkIt-KMP/feature/*/src/commonMain -name \"*.kt\" -type f)",
+      "Bash(git -C /Users/yuhohyeon/Desktop/project/LinkIt-KMP log --oneline -15)",
+      "Bash(git -C /Users/yuhohyeon/Desktop/project/LinkIt-KMP branch -a)",
+      "Bash(./gradlew :feature:intro:tasks --all)",
+      "Bash(./gradlew :feature:intro:compileDebugKotlinAndroid)"
+    ],
+    "additionalDirectories": [
+      "/Users/yuhohyeon/Desktop/project/LinkIt-KMP/.claude"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+LinkIt-KMP is a Kotlin Multiplatform (KMP) project targeting Android and iOS, built with Compose Multiplatform and Clean Architecture.
+
+## Build Commands
+
+```shell
+# Android
+./gradlew :app:assembleDebug
+
+# Full build check
+./gradlew build
+
+# Single module build
+./gradlew :feature:home:build
+./gradlew :core:navigation:build
+```
+
+iOS is built via Xcode from the `iosApp/` directory.
+
+## Architecture
+
+**Clean Architecture with multi-module structure.** Dependency rules are strict:
+
+```
+app → feature-*, domain, data, core-*
+feature-* → domain, core-* (NO inter-feature dependencies)
+data → domain, core-*
+domain → core-common (pure Kotlin, platform-independent)
+core:designsystem → core:common
+core:navigation → core:common
+```
+
+### Module Roles
+
+- **app**: Entry point, wires navigation routes to feature screens via `LinkItEntryProvider`
+- **core:navigation**: Navigation3 wrapper (`LinkItRoute`, `LinkItNavigator`, `LinkItNavDisplay`)
+- **core:designsystem**: Material3 theme (colors, typography)
+- **core:common**: `Result` sealed class, constants, utilities
+- **domain**: Business logic, repository interfaces, use cases
+- **data**: Repository implementations, data sources, DTOs, mappers
+- **feature:***: Pure composable screens that accept callback lambdas (no direct navigation dependency)
+
+### Navigation Pattern (Navigation3)
+
+Routes are defined as `@Serializable` sealed interface members in `core/navigation/.../LinkItRoute.kt`. Route-to-screen mapping is done in `app/.../navigation/LinkItEntryProvider.kt` using the `entryProvider` DSL. Screens receive navigation callbacks via `LocalLinkItNavigator` (CompositionLocal), never depending on navigation directly.
+
+`LinkItNavigator` wraps `SnapshotStateList<LinkItRoute>` and exposes: `navigate(route)`, `popBack()`, `navigateAndClearStack(route)`.
+
+### Platform Entry Points
+
+- **Android**: `IntroActivity` (launcher) → `MainActivity` which calls `LinkItApp()`
+- **iOS**: `IntroViewController` / `MainViewController` via `ComposeUIViewController`, wrapped in SwiftUI via `ContentView.swift`
+
+## Build System
+
+Convention plugins in `build-logic/conventions/` provide shared config:
+- `kmp.application.convention` — app module
+- `kmp.library.convention` — library modules
+- `kmp.feature.convention` — feature modules (adds Compose dependencies)
+- `kmp.core.convention` — core modules
+
+Targets: `androidTarget` (JVM 11, compileSdk 36, minSdk 24), `iosArm64`, `iosSimulatorArm64`.
+
+## Adding a New Feature
+
+1. Create module under `feature/`
+2. Add to `settings.gradle.kts`
+3. Apply `kmp.feature.convention` plugin in its `build.gradle.kts`
+4. Add dependency in `app/build.gradle.kts`
+5. Define route in `LinkItRoute.kt`, map it in `LinkItEntryProvider.kt`
+
+## Language
+
+Project documentation and commit messages are in Korean. Code (identifiers, comments) is in English.

--- a/feature/intro/build.gradle.kts
+++ b/feature/intro/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("kmp.feature.convention")
+}
+
+android {
+    namespace = "com.linkit.company.feature.intro"
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.core.common)
+            implementation(projects.core.designsystem)
+            implementation(projects.domain)
+        }
+    }
+}

--- a/feature/intro/src/commonMain/kotlin/com/linkit/company/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/commonMain/kotlin/com/linkit/company/feature/intro/IntroScreen.kt
@@ -1,0 +1,120 @@
+package com.linkit.company.feature.intro
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun IntroScreen(
+    onNavigateToHome: () -> Unit = {},
+) {
+    val visible = remember {
+        MutableTransitionState(false).apply { targetState = true }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        AnimatedVisibility(
+            visibleState = visible,
+            enter = fadeIn(tween(800)) + slideInVertically(
+                animationSpec = tween(800),
+                initialOffsetY = { -40 },
+            ),
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Box(
+                    modifier = Modifier
+                        .size(100.dp)
+                        .clip(RoundedCornerShape(24.dp))
+                        .background(MaterialTheme.colorScheme.primary),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "L",
+                        fontSize = 48.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = "LinkIt",
+                    style = MaterialTheme.typography.displaySmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        AnimatedVisibility(
+            visibleState = visible,
+            enter = fadeIn(tween(800, delayMillis = 400)),
+        ) {
+            Text(
+                text = "링크를 잇다, 사람을 잇다",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f),
+                textAlign = TextAlign.Center,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(64.dp))
+
+        AnimatedVisibility(
+            visibleState = visible,
+            enter = fadeIn(tween(600, delayMillis = 800)) + slideInVertically(
+                animationSpec = tween(600, delayMillis = 800),
+                initialOffsetY = { 30 },
+            ),
+        ) {
+            Button(
+                onClick = onNavigateToHome,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                shape = RoundedCornerShape(16.dp),
+            ) {
+                Text(
+                    text = "시작하기",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,6 +42,7 @@ include(":domain")
 include(":data")
 
 // Features
+include(":feature:intro")
 include(":feature:home")
 include(":feature:classification")
 include(":feature:onboarding")


### PR DESCRIPTION
### What is this PR (Required)
- **Issue Number** : close #5
- 기타 관련 문서 :

### Changes (Required)
- `feature:intro` 모듈 신규 생성 및 `settings.gradle.kts`에 등록
- `IntroScreen` 구현: 앱 로고(L), 앱명(LinkIt), 서브타이틀, 시작하기 버튼 + 순차 페이드인/슬라이드 애니메이션
- `.claude/commands/pr.md` 커스텀 명령어 추가 (PR 자동 생성 워크플로우)
- `CLAUDE.md` 프로젝트 가이드 문서 작성 (아키텍처, 빌드, 컨벤션 등)
- `.claude/settings.json` 추가

### Review Point (Required)
- IntroScreen의 애니메이션 구조: 단일 `MutableTransitionState`로 3개 섹션의 시차 애니메이션을 `delayMillis`로 처리
- CLAUDE.md의 프로젝트 아키텍처 및 컨벤션 설명이 실제 프로젝트와 일치하는지 확인