### PR TITLE
docs: data·domain 모듈 하네스 문서 작성

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,20 @@ main          ← 최상위 (릴리스)
 - 새 모듈을 추가하거나 모듈 간 의존성을 변경할 때
 - 아키텍처 설계 판단이 필요할 때
 
+### domain/README.md
+아래 상황에서 반드시 읽고 참고할 것:
+- 도메인 모델, Repository 인터페이스, UseCase를 추가하거나 수정할 때
+- UseCase를 만들지 말지(생성·생략 기준) 판단이 필요할 때
+- ViewModel에 비즈니스 로직을 배치할지 고민될 때
+- `withContext`, `Dispatchers` 지정이 필요한지 판단할 때 (디스패처 규칙)
+
+### data/README.md
+아래 상황에서 반드시 읽고 참고할 것:
+- 새 API, DataSource, Repository를 추가하거나 수정할 때
+- DTO, Mapper를 작성할 때
+- Ktorfit, HttpClient 등 네트워크 설정 관련 작업을 할 때
+- data 모듈의 DI 그래프(DataGraph, DataSourceGraph, RepositoryGraph)를 수정할 때
+
 ### docs/NAVIGATION_STRUCTURE.md
 아래 상황에서 반드시 읽고 참고할 것:
 - Navigation 관련 코드를 수정하거나 새 Route를 추가할 때

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,20 @@ main          ← 최상위 (릴리스)
 - 새 모듈을 추가하거나 모듈 간 의존성을 변경할 때
 - 아키텍처 설계 판단이 필요할 때
 
+### domain/README.md
+아래 상황에서 반드시 읽고 참고할 것:
+- 도메인 모델, Repository 인터페이스, UseCase를 추가하거나 수정할 때
+- UseCase를 만들지 말지(생성·생략 기준) 판단이 필요할 때
+- ViewModel에 비즈니스 로직을 배치할지 고민될 때
+- `withContext`, `Dispatchers` 지정이 필요한지 판단할 때 (디스패처 규칙)
+
+### data/README.md
+아래 상황에서 반드시 읽고 참고할 것:
+- 새 API, DataSource, Repository를 추가하거나 수정할 때
+- DTO, Mapper를 작성할 때
+- Ktorfit, HttpClient 등 네트워크 설정 관련 작업을 할 때
+- data 모듈의 DI 그래프(DataGraph, DataSourceGraph, RepositoryGraph)를 수정할 때
+
 ### docs/NAVIGATION_STRUCTURE.md
 아래 상황에서 반드시 읽고 참고할 것:
 - Navigation 관련 코드를 수정하거나 새 Route를 추가할 때

--- a/app-shared/src/iosMain/kotlin/com/linkit/company/IosAppGraph.kt
+++ b/app-shared/src/iosMain/kotlin/com/linkit/company/IosAppGraph.kt
@@ -4,8 +4,8 @@ import com.linkit.company.core.common.AppGraph
 import com.linkit.company.data.DataScope
 import com.linkit.company.data.core.defaultJson
 import com.linkit.company.data.core.defaultKtorConfig
-import com.linkit.company.data.datasource.sample.SampleDataSource
-import com.linkit.company.data.datasource.sample.SampleDataSourceImpl
+import com.linkit.company.data.datasource.sample.SampleRemoteDataSource
+import com.linkit.company.data.datasource.sample.SampleRemoteDataSourceImpl
 import com.linkit.company.data.repository.SampleRepositoryImpl
 import com.linkit.company.domain.repository.SampleRepository
 import androidx.lifecycle.ViewModel
@@ -46,7 +46,7 @@ import kotlinx.serialization.json.Json
 interface IosAppGraph : AppGraph {
 
     @Binds
-    val SampleDataSourceImpl.bind: SampleDataSource
+    val SampleRemoteDataSourceImpl.bind: SampleRemoteDataSource
 
     @Binds
     val SampleRepositoryImpl.bind: SampleRepository

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,451 @@
+# data 모듈
+
+Repository 구현체, DataSource, DTO, Mapper, 네트워크 설정을 제공하는 KMP 라이브러리 모듈이다.
+클린아키텍처의 데이터 계층으로, 외부(feature 모듈)에서는 `domain` 모듈의 Repository 인터페이스만 바라보고 이 모듈의 구현체는 Metro DI를 통해 주입된다.
+
+이 문서의 예시 코드는 가상의 `Link` 도메인을 기준으로 작성된 가이드 코드이며, 형식만 참고할 것.
+
+## 레이어 흐름
+
+```
+ViewModel (feature)
+    ↓
+Repository 인터페이스 (domain)
+    ↓ Metro @Binds
+RepositoryImpl (data/repository)     ← DTO/Entity → Domain 변환, 출처 조율(캐싱) 지점
+    ↓                        ↓
+RemoteDataSource 인터페이스   LocalDataSource 인터페이스   (data/datasource)
+    ↓ Metro @Binds            ↓ Metro @Binds
+RemoteDataSourceImpl         LocalDataSourceImpl
+    ↓ (Ktorfit API 호출,       ↓ (로컬 저장소 접근,
+       DTO 반환)                 Entity 반환 — 도입 예정)
+Ktorfit API 인터페이스 (data/api)
+    ↓
+HttpClient (Android: OkHttp / iOS: Darwin)
+```
+
+각 계층은 아래 계층의 **인터페이스에만 의존**하고, 구현체 연결은 Metro DI가 담당한다.
+DataSource는 출처(원격/로컬)별로 분리하며, 두 출처의 조합은 Repository가 담당한다.
+
+## 디렉토리 구조
+
+```
+data/src/
+├── commonMain/kotlin/com/linkit/company/data/
+│   ├── api/                  # Ktorfit API 인터페이스
+│   ├── core/                 # KtorConfig (HttpClient 공통 설정, Json 설정)
+│   ├── dto/                  # 서버 응답/요청 DTO (@Serializable)
+│   ├── mapper/               # DTO → Domain 모델 변환 확장 함수
+│   ├── datasource/
+│   │   ├── {도메인}/          # 도메인별 Remote/Local DataSource 인터페이스 + Impl
+│   │   └── DataSourceGraph.kt # DataSource @Binds 등록
+│   ├── repository/           # domain Repository 인터페이스의 구현체
+│   ├── DataGraph.kt          # baseUrl, Json, Ktorfit 제공
+│   ├── DataScope.kt          # data 계층 Metro 스코프
+│   └── RepositoryGraph.kt    # Repository @Binds 등록
+└── androidMain/kotlin/com/linkit/company/data/
+    └── AndroidDataGraph.kt   # Android용 HttpClient(OkHttp) 제공
+```
+
+## 네트워크 레이어 구성
+
+### HttpClient 공통 설정 — `core/KtorConfig.kt`
+
+플랫폼별 HttpClient가 공유하는 설정은 `defaultKtorConfig()` / `defaultJson()`에 모여 있다.
+
+- `ContentNegotiation` + kotlinx.serialization Json
+- `ignoreUnknownKeys = true` : 서버에 새 필드가 추가돼도 파싱이 깨지지 않도록 함
+- `isLenient = true`, `encodeDefaults = true`
+
+### 플랫폼별 HttpClient 제공 위치
+
+| 플랫폼 | 엔진 | 제공 위치 |
+| --- | --- | --- |
+| Android | OkHttp | `data/androidMain` — `AndroidDataGraph` |
+| iOS | Darwin | `app-shared/iosMain` — `IosAppGraph` (수동 등록) |
+
+data 모듈에는 iosMain 소스셋이 없으므로, iOS의 HttpClient는 `IosAppGraph`에서 직접 제공한다. iOS DI 관련 제약은 [docs/METRO_INSTRUCTION.md](../docs/METRO_INSTRUCTION.md) 참고.
+
+### Ktorfit 인스턴스 — `DataGraph`
+
+`DataGraph`가 `baseUrl`, `Json`, `Ktorfit`을 `DataScope`에 제공한다.
+
+```kotlin
+@ContributesTo(DataScope::class)
+interface DataGraph {
+
+    @Provides
+    fun provideBaseUrl(): String = "..."
+
+    @Provides
+    fun provideJson(): Json = defaultJson()
+
+    @Provides
+    fun provideKtorfit(httpClient: HttpClient, baseUrl: String): Ktorfit {
+        return Ktorfit.Builder()
+            .httpClient(httpClient)
+            .baseUrl(baseUrl)
+            .build()
+    }
+}
+```
+
+`DataScope`는 `AndroidAppGraph` / `IosAppGraph`의 `additionalScopes = [DataScope::class]`로 앱 그래프에 병합되므로, `@ContributesTo(DataScope::class)`로 기여한 바인딩은 Android에서는 별도 등록 없이 사용 가능하다. 단, **iOS는 멀티모듈 자동 수집이 동작하지 않아** `IosAppGraph`에 동일한 `@Binds`를 수동 등록해야 한다 — [docs/METRO_INSTRUCTION.md](../docs/METRO_INSTRUCTION.md) 참고.
+
+## Ktorfit API 작성 규칙
+
+`api/` 패키지에 `internal interface`로 작성한다. Ktorfit 어노테이션(`@GET`, `@POST`, `@Path`, `@Query`, `@Body` 등)으로 엔드포인트를 선언하면 컴파일러 플러그인이 구현체를 생성한다.
+
+```kotlin
+// api/LinkApi.kt
+internal interface LinkApi {
+
+    @GET("links")
+    suspend fun getLinks(): ApiResponse<List<LinkResponse>>
+
+    @GET("links/{id}")
+    suspend fun getLink(@Path("id") id: Long): ApiResponse<LinkResponse>
+
+    @POST("links")
+    suspend fun createLink(@Body request: CreateLinkRequest): ApiResponse<LinkResponse>
+
+    @DELETE("links/{id}")
+    suspend fun deleteLink(@Path("id") id: Long): ApiResponse<Unit>
+}
+```
+
+- 가시성은 `internal` — API 인터페이스는 data 모듈 밖으로 노출하지 않는다
+- 엔드포인트는 baseUrl 기준 상대 경로로 작성한다
+- 반환 타입은 항상 `ApiResponse<DTO>` — domain 모델을 직접 반환하지 않는다 ([공통 응답 구조](#공통-응답-구조) 참고)
+- 응답 데이터가 없는 API(삭제 등)는 `ApiResponse<Unit>`으로 선언한다
+
+API 인스턴스는 DataSourceImpl에서 `ktorfit.create<LinkApi>()`로 생성한다 (컴파일러 플러그인이 처리).
+
+## 공통 응답 구조
+
+서버([LinkTrip API](https://linktrip.cloud/api/swagger-ui/index.html))의 모든 응답은 아래 두 가지 구조 중 하나를 따른다.
+**성공(2xx)과 실패(4xx/5xx)의 바디 구조가 서로 다르다**는 점에 주의할 것.
+
+### 성공 응답 (2xx) — 공통 래퍼
+
+모든 성공 응답은 동일한 래퍼로 감싸져 온다.
+
+```json
+{
+  "status": 200,
+  "message": "OK",
+  "data": { ... }
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+| --- | --- | --- | --- |
+| `status` | Int | O | HTTP 상태 코드 |
+| `message` | String | O | 응답 메시지 |
+| `data` | T | X | 응답 데이터. **없으면 필드 자체가 생략됨** (예: 삭제 API) |
+
+#### 2xx 코드별 의미
+
+성공은 200만이 아니다. 코드에 따라 클라이언트 처리가 달라진다.
+
+| 코드 | 의미 | 사용 API 예시 |
+| --- | --- | --- |
+| 200 | 요청 성공 | 전체 |
+| 201 | 리소스 생성 | `POST /auth/login` — 신규 회원 가입 시 |
+| 202 | 처리 진행 중 → **폴링 필요** | `POST /video/analyze`, `GET /video/schedule/{id}` — 영상 분석 PENDING/PROCESSING 상태 |
+
+201/202도 바디는 200과 동일한 공통 래퍼 구조다.
+
+### 실패 응답 (4xx/5xx)
+
+실패 응답은 공통 래퍼가 **아닌** 별도 구조로 온다.
+
+```json
+{
+  "code": "NOT_FOUND_TRIP_PLAN",
+  "message": "여행 계획을 찾을 수 없습니다."
+}
+```
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `code` | String | 에러 식별 코드 (아래 표 참고) |
+| `message` | String | 사용자 노출 가능한 에러 메시지 |
+
+#### 에러 코드 목록
+
+| HTTP | `code` | 의미 | 발생 API |
+| --- | --- | --- | --- |
+| 400 | `BAD_REQUEST_VALIDATION` | 요청 값 validation 실패 | `POST /auth/login` |
+| 400 | `BAD_REQUEST_MISSING_IDEMPOTENCY_KEY` | Idempotency-Key 헤더 누락 | 멱등성 키 필수 API 전체 |
+| 400 | `BAD_REQUEST_YOUTUBE_URL` | 유효하지 않은 YouTube URL | `POST /video/analyze` |
+| 400 | `BAD_REQUEST_VIDEO` | 자막을 추출할 수 없는 영상 | `POST /video/analyze` |
+| 400 | `BAD_REQUEST_DISCOVER_QUERY` | `country`/`region` 동시 사용 불가 | `GET /video/discover/category` |
+| 403 | `FORBIDDEN_TRIP_PLAN` | 본인의 여행 계획이 아님 | `GET/PUT/DELETE /trip-plans/{id}` |
+| 404 | `NOT_FOUND_TRIP_PLAN` | 존재하지 않는 여행 계획 | `GET/PUT/DELETE /trip-plans/{id}` |
+| 404 | `NOT_FOUND_VIDEO_ANALYSIS_TASK` | 존재하지 않는 영상 분석 결과 | `GET /video/schedule/{id}` |
+| 409 | `DUPLICATE_REQUEST` | 동일 멱등성 키의 요청이 이미 처리 중 | 멱등성 키 필수 API 전체 |
+| 429 | `TOO_MANY_REQUESTS` | API 요청 횟수 초과 | `POST /video/analyze` |
+
+### Kotlin 표현 가이드
+
+공통 래퍼와 에러 바디는 `dto/`에 아래 형태로 표현한다.
+
+```kotlin
+// dto/ApiResponse.kt — 성공 응답 공통 래퍼
+@Serializable
+internal data class ApiResponse<T>(
+    val status: Int,
+    val message: String,
+    val data: T? = null,   // 서버가 필드를 생략할 수 있으므로 nullable + 기본값 필수
+)
+
+// dto/ErrorResponse.kt — 실패 응답 바디
+@Serializable
+internal data class ErrorResponse(
+    val code: String,
+    val message: String,
+)
+```
+
+- 실패(4xx/5xx) 처리는 Ktor `HttpResponseValidator`에서 `ErrorResponse`를 파싱해 공통 예외로 변환하는 방향으로 한다 — 구현 도입 시 이 섹션에 예외 타입과 처리 규칙을 추가할 것
+
+### Idempotency-Key 규칙
+
+non-GET 요청은 `Idempotency-Key` 헤더가 **필수**다 (UUID v4 권장).
+
+| 대상 API | 누락 시 | 동일 키 중복 요청 시 |
+| --- | --- | --- |
+| `POST /auth/login`, `POST /video/analyze`, `PUT/DELETE /trip-plans/{id}` | 400 `BAD_REQUEST_MISSING_IDEMPOTENCY_KEY` | 409 `DUPLICATE_REQUEST` |
+
+## DTO 작성 규칙
+
+`dto/` 패키지에 `@Serializable` data class로 작성한다.
+
+```kotlin
+// dto/LinkResponse.kt
+@Serializable
+internal data class LinkResponse(
+    val id: Long,
+    val title: String,
+    val url: String,
+    val memo: String? = null,
+)
+
+// dto/CreateLinkRequest.kt
+@Serializable
+internal data class CreateLinkRequest(
+    val title: String,
+    val url: String,
+    val memo: String? = null,
+)
+```
+
+- 서버 응답/요청 스키마를 그대로 반영한다 — 서버가 nullable이면 DTO도 nullable
+- 서버 필드명과 다르게 쓰려면 `@SerialName("server_name")` 사용
+- 요청 바디용 DTO는 `XxxRequest`, 응답용은 `XxxResponse` 네이밍
+
+### Request DTO 생성 기준
+
+| 상황 | 방식 |
+| --- | --- |
+| 파라미터 2개 이상 | `XxxRequest` data class 생성 |
+| 단일 필드라도 서버가 JSON 객체 바디 요구 | `XxxRequest` data class 생성 (원시값을 `@Body`로 보내면 객체가 아닌 bare value로 직렬화됨) |
+| 단일 파라미터 (`@Path`, `@Query`) | DTO 없이 원시값으로 전달 |
+
+- `encodeDefaults = true` 설정이므로 기본값을 가진 필드도 항상 직렬화되어 전송된다 — "필드를 아예 보내지 않음"이 필요한 경우 별도 처리가 필요함을 주의
+
+## Mapper 작성 규칙 (DTO → Domain 모델)
+
+`mapper/` 패키지에 **DTO의 확장 함수**로 작성한다. domain 모델의 non-null 보장, 기본값 처리는 이 지점에서 끝낸다.
+
+```kotlin
+// mapper/LinkMapper.kt
+internal fun LinkResponse.toDomain(): Link {
+    return Link(
+        id = id,
+        title = title,
+        url = url,
+        memo = memo.orEmpty(),
+    )
+}
+```
+
+- 함수명은 `toDomain()`, 파일명은 `{도메인}Mapper.kt`
+- Mapper는 반드시 data 모듈에 둔다 — domain 모듈에 두면 domain이 data(DTO)에 역의존하게 된다
+- nullable 필드는 여기서 `.orEmpty()`, `?: 기본값` 등으로 정리하여 domain 모델을 깨끗하게 유지한다
+- **Request DTO는 매퍼를 거치지 않는다** — DataSourceImpl에서 직접 생성하며, 역방향 매퍼(`toRequest()`)를 만들지 않는다
+
+## DataSource 작성 규칙
+
+`datasource/{도메인}/` 패키지에 인터페이스 + Impl 쌍으로 작성한다.
+데이터 출처에 따라 `Remote` / `Local` 접미사를 **항상 명시**한다 — 출처가 하나뿐이어도 생략하지 않는다.
+
+```
+datasource/link/
+├── LinkRemoteDataSource.kt (+ Impl)   # 원격 API 호출
+└── LinkLocalDataSource.kt  (+ Impl)   # 로컬 저장소 접근 (필요한 도메인만)
+```
+
+출처 공통 규칙:
+
+- 데이터 출처 호출만 담당하고 비즈니스 로직을 넣지 않는다
+- **다른 DataSource를 주입/참조하지 않는다** — Remote/Local 조합은 Repository의 책임
+- domain 모델을 반환하거나 파라미터로 받지 않는다 — **파라미터는 원시값, 반환은 DTO/Entity**
+- Impl에는 Metro `@Inject`를 붙여 생성자 주입을 활성화한다
+- 작성 후 `DataSourceGraph`에 `@Binds`로 등록한다
+
+### RemoteDataSource — 원격 API 호출
+
+Ktorfit API를 호출하고 **DTO만 반환한다**. 파라미터는 원시값으로 받고, **Request DTO 조립은 Impl 내부에서** 한다.
+
+```kotlin
+// datasource/link/LinkRemoteDataSource.kt
+interface LinkRemoteDataSource {
+    suspend fun getLinks(): List<LinkResponse>
+    suspend fun deleteLink(id: Long)
+    suspend fun createLink(title: String, url: String, memo: String?): LinkResponse
+}
+
+// datasource/link/LinkRemoteDataSourceImpl.kt
+@Inject
+class LinkRemoteDataSourceImpl(
+    ktorfit: Ktorfit,
+) : LinkRemoteDataSource {
+
+    private val api = ktorfit.create<LinkApi>()
+
+    override suspend fun getLinks(): List<LinkResponse> {
+        return api.getLinks().data.orEmpty()
+    }
+
+    override suspend fun deleteLink(id: Long) {
+        api.deleteLink(id)
+    }
+
+    override suspend fun createLink(title: String, url: String, memo: String?): LinkResponse {
+        val request = CreateLinkRequest(
+            title = title,
+            url = url,
+            memo = memo,
+        )
+        return checkNotNull(api.createLink(request).data)
+    }
+}
+```
+
+- `data`가 반드시 있어야 하는 응답은 `checkNotNull`로, 리스트 응답은 `orEmpty()`로 언래핑한다. 응답 데이터가 없는 API(`ApiResponse<Unit>`)는 `data`를 무시한다
+
+### LocalDataSource — 로컬 저장소 접근
+
+로컬 저장소(DB, 캐시, 설정 등)에 접근하고 **저장 모델(Entity 등)만 반환한다**.
+
+- 반환 타입은 저장 기술의 모델 — DTO나 domain 모델을 반환하지 않는다
+- Entity ↔ Domain 변환도 `mapper/`에 두며, 변환 책임은 Repository에 있다
+
+> 로컬 저장소 기술(Room KMP, DataStore 등)은 아직 도입 전이다.
+> 도입 시 이 섹션에 저장 기술별 작성 규칙과 예시 코드를 추가할 것.
+
+### DataSourceGraph 등록
+
+```kotlin
+@ContributesTo(DataScope::class)
+internal interface DataSourceGraph {
+
+    @Binds
+    val LinkRemoteDataSourceImpl.bind: LinkRemoteDataSource
+
+    @Binds
+    val LinkLocalDataSourceImpl.bind: LinkLocalDataSource
+}
+```
+
+## Repository 작성 규칙
+
+Repository **인터페이스는 domain 모듈**(`domain/repository/`)에, **구현체는 data 모듈**(`repository/`)에 둔다.
+인터페이스 작성 규칙(시그니처, suspend vs Flow)은 [domain/README.md](../domain/README.md#repository-인터페이스-작성-규칙)가 단일 출처이며, 이 섹션은 구현체 규칙만 다룬다.
+
+```kotlin
+// data 모듈: repository/LinkRepositoryImpl.kt
+@Inject
+class LinkRepositoryImpl(
+    private val linkRemoteDataSource: LinkRemoteDataSource,
+) : LinkRepository {
+
+    override suspend fun getLinks(): List<Link> {
+        return linkRemoteDataSource.getLinks().map { it.toDomain() }
+    }
+
+    override suspend fun createLink(title: String, url: String, memo: String?): Link {
+        return linkRemoteDataSource.createLink(title, url, memo).toDomain()
+    }
+
+    override suspend fun deleteLink(id: Long) {
+        linkRemoteDataSource.deleteLink(id)
+    }
+}
+```
+
+- DataSource **인터페이스**만 주입받는다 (Impl 직접 참조 금지)
+- 반환 전에 반드시 `toDomain()`으로 변환한다 — DTO/Entity가 domain 계층으로 새어 나가면 안 된다. 응답 바디가 없는 요청은 변환 없이 `Unit`으로 끝낸다
+- 요청 데이터는 **개별 파라미터**로 받아 그대로 DataSource에 전달한다 — 인터페이스가 domain 모듈에 있으므로 시그니처에 DTO가 나타나면 안 된다
+- **Remote/Local 조합과 캐싱 전략은 Repository만의 책임이다** — 예: 로컬 우선 조회 → 없으면 원격 조회 → 로컬 저장. DataSource에는 이런 조율 로직을 두지 않는다
+- **캐싱 전략은 도메인별 자율로 결정한다** — 프로젝트 차원의 표준 전략(local-first 등)을 강제하지 않으며, 각 도메인의 데이터 특성에 맞는 전략을 해당 RepositoryImpl에서 선택한다. 선택한 전략은 RepositoryImpl 구현으로 드러나도록 작성한다
+
+작성 후 `RepositoryGraph`에 `@Binds`로 등록한다.
+
+```kotlin
+@ContributesTo(DataScope::class)
+internal interface RepositoryGraph {
+
+    @Binds
+    val LinkRepositoryImpl.bind: LinkRepository
+}
+```
+
+## 새 API 추가 절차
+
+가상의 `Link` 도메인 기준 전체 절차:
+
+1. **DTO 작성** — `dto/LinkResponse.kt` (`@Serializable`), 파라미터 2개 이상인 요청이면 `dto/CreateLinkRequest.kt`도 함께
+2. **domain 모델 작성** — `domain` 모듈에 `Link` data class 추가
+3. **Mapper 작성** — `mapper/LinkMapper.kt`에 `LinkResponse.toDomain()` 확장 함수
+4. **Ktorfit API 작성** — `api/LinkApi.kt`에 엔드포인트 선언 (기존 API에 함수 추가도 가능)
+5. **RemoteDataSource 작성** — `datasource/link/`에 `LinkRemoteDataSource` + `LinkRemoteDataSourceImpl`
+6. **DataSource 등록** — `DataSourceGraph`에 `@Binds` 추가
+7. **Repository 인터페이스 작성** — `domain` 모듈 `repository/LinkRepository.kt`
+8. **RepositoryImpl 작성** — `repository/LinkRepositoryImpl.kt`
+9. **Repository 등록** — `RepositoryGraph`에 `@Binds` 추가
+10. **iOS 수동 등록** — `IosAppGraph`에 DataSource/Repository `@Binds`를 수동 추가 (iOS는 멀티모듈 자동 수집이 동작하지 않음)
+
+Android는 9단계까지로 주입 가능하지만, **iOS는 10단계까지 마쳐야 한다**. Metro 관련 에러(MissingBinding 등)가 발생하면 [docs/METRO_INSTRUCTION.md](../docs/METRO_INSTRUCTION.md)를 참고한다.
+
+로컬 캐싱이 필요한 경우 아래 단계를 추가한다:
+
+1. **Entity 작성** — 저장 기술의 모델 정의 (저장 기술 도입 후 규칙 확정)
+2. **Entity Mapper 작성** — `mapper/`에 Entity ↔ Domain 변환 확장 함수
+3. **LocalDataSource 작성** — `datasource/link/`에 `LinkLocalDataSource` + Impl, `DataSourceGraph`에 `@Binds` 추가
+4. **Repository에서 조율** — RepositoryImpl에 Remote/Local을 함께 주입받아 캐싱 전략 구현 (전략은 도메인별 자율)
+
+## 금지 규칙 (안티패턴)
+
+| 금지 사항 | 이유 |
+| --- | --- |
+| feature 모듈이 data 모듈에 직접 의존 | feature는 domain만 의존해야 함 — 의존 방향은 [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md#의존성-규칙)가 단일 출처 |
+| DataSource가 domain 모델을 반환하거나 파라미터로 받음 | 변환 책임은 Repository에 있음. 파라미터는 원시값으로 받을 것 |
+| domain Repository 인터페이스 시그니처에 Request DTO 사용 | DTO가 domain 계층으로 유출됨. 개별 파라미터로 받을 것 |
+| DataSourceImpl 밖에서 Request DTO 조립 | Request DTO는 DataSourceImpl 내부에서만 생성하여 API 계층에 전달 |
+| DataSource 네이밍에 `Remote`/`Local` 접미사 생략 | 출처가 하나뿐이어도 항상 명시. 나중에 출처 추가 시 rename 연쇄 발생 |
+| DataSource가 다른 DataSource를 주입/참조 | 출처 조합·캐싱 전략은 Repository의 책임 |
+| DataSource 인터페이스 시그니처에 `ApiResponse` 노출 | 래퍼 언래핑은 DataSourceImpl 내부의 책임. 인터페이스는 알맹이 DTO만 반환할 것 |
+| Repository가 DTO를 반환/노출 | DTO가 domain·feature 계층으로 유출되어 서버 스키마 변경이 전파됨 |
+| Mapper를 domain 모듈에 배치 | domain이 data(DTO)에 역의존하게 됨 |
+| `DataGraph` 밖에서 Ktorfit/HttpClient 직접 생성 | 설정이 분산되고 인스턴스가 중복 생성됨 |
+| DataSourceImpl에 비즈니스 로직 작성 | DataSource는 데이터 출처 호출만 담당 |
+| suspend API(Ktor 등)를 관성적으로 `withContext(Dispatchers.IO)`로 래핑 | Ktor suspend API는 자체 메인 세이프. 블로킹 API를 suspend로 감쌀 때만 전환 — [domain/README.md 디스패처 규칙](../domain/README.md#디스패처-규칙--메인-세이프-계약) 참고 |
+
+## 의존성 추가 가이드
+
+- 네트워크·직렬화 등 데이터 계층 전용 라이브러리는 `data/build.gradle.kts`에만 추가한다
+- Android 전용 엔진/라이브러리는 `androidMain.dependencies`에, 공통은 `commonMain.dependencies`에 추가한다
+- iOS 전용(Darwin 엔진 등)은 현재 `app-shared`에서 관리한다

--- a/data/src/commonMain/kotlin/com/linkit/company/data/datasource/DataSourceGraph.kt
+++ b/data/src/commonMain/kotlin/com/linkit/company/data/datasource/DataSourceGraph.kt
@@ -1,8 +1,8 @@
 package com.linkit.company.data.datasource
 
 import com.linkit.company.data.DataScope
-import com.linkit.company.data.datasource.sample.SampleDataSource
-import com.linkit.company.data.datasource.sample.SampleDataSourceImpl
+import com.linkit.company.data.datasource.sample.SampleRemoteDataSource
+import com.linkit.company.data.datasource.sample.SampleRemoteDataSourceImpl
 import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.ContributesTo
 
@@ -10,5 +10,5 @@ import dev.zacsweers.metro.ContributesTo
 internal interface DataSourceGraph {
 
     @Binds
-    val SampleDataSourceImpl.bind: SampleDataSource
+    val SampleRemoteDataSourceImpl.bind: SampleRemoteDataSource
 }

--- a/data/src/commonMain/kotlin/com/linkit/company/data/datasource/sample/SampleRemoteDataSource.kt
+++ b/data/src/commonMain/kotlin/com/linkit/company/data/datasource/sample/SampleRemoteDataSource.kt
@@ -1,5 +1,5 @@
 package com.linkit.company.data.datasource.sample
 
-interface SampleDataSource {
+interface SampleRemoteDataSource {
     suspend fun getSample(): String
 }

--- a/data/src/commonMain/kotlin/com/linkit/company/data/datasource/sample/SampleRemoteDataSourceImpl.kt
+++ b/data/src/commonMain/kotlin/com/linkit/company/data/datasource/sample/SampleRemoteDataSourceImpl.kt
@@ -5,9 +5,9 @@ import de.jensklingenberg.ktorfit.Ktorfit
 import dev.zacsweers.metro.Inject
 
 @Inject
-class SampleDataSourceImpl(
+class SampleRemoteDataSourceImpl(
     ktorfit: Ktorfit
-) : SampleDataSource {
+) : SampleRemoteDataSource {
     /**
      * Auto compile by compiler plugin
      * see : https://github.com/Foso/Ktorfit/blob/399dfb3f9bac4bc67aaf98b7dfaa65febd2ad6f5/ktorfit-lib-core/src/commonMain/kotlin/de/jensklingenberg/ktorfit/Ktorfit.kt#L90

--- a/data/src/commonMain/kotlin/com/linkit/company/data/repository/SampleRepositoryImpl.kt
+++ b/data/src/commonMain/kotlin/com/linkit/company/data/repository/SampleRepositoryImpl.kt
@@ -1,14 +1,14 @@
 package com.linkit.company.data.repository
 
-import com.linkit.company.data.datasource.sample.SampleDataSource
+import com.linkit.company.data.datasource.sample.SampleRemoteDataSource
 import com.linkit.company.domain.repository.SampleRepository
 import dev.zacsweers.metro.Inject
 
 @Inject
 class SampleRepositoryImpl(
-    private val sampleDataSource: SampleDataSource,
+    private val sampleRemoteDataSource: SampleRemoteDataSource,
 ) : SampleRepository {
     override suspend fun getSample(): String {
-        return sampleDataSource.getSample()
+        return sampleRemoteDataSource.getSample()
     }
 }

--- a/domain/README.md
+++ b/domain/README.md
@@ -1,0 +1,178 @@
+# domain 모듈
+
+도메인 모델, Repository 인터페이스, UseCase를 제공하는 KMP 라이브러리 모듈이다.
+클린아키텍처의 도메인 계층으로, ViewModel(feature)과 데이터 계층(data) 사이의 경계를 정의한다.
+feature 모듈은 이 모듈의 인터페이스만 바라보고, 구현체(RepositoryImpl)는 Metro DI를 통해 주입된다.
+
+이 문서의 예시 코드는 가상의 `Link` 도메인을 기준으로 작성된 가이드 코드이며, 형식만 참고할 것.
+
+> 이 모듈은 **순수 Kotlin(commonMain)** 으로만 구성한다. Android SDK, Compose, Ktor 등 플랫폼·UI·네트워크 타입을 두지 않으며, 덕분에 플랫폼 환경 없이 공통 단위 테스트가 가능하다.
+
+## 레이어 흐름
+
+```
+ViewModel (feature)
+    ↓ 비즈니스 규칙이 있으면        ↓ 단순 조회면 직접
+UseCase (domain/usecase)
+    ↓
+Repository 인터페이스 (domain/repository)
+    ↓ Metro @Binds
+RepositoryImpl (data/repository)
+```
+
+ViewModel은 UseCase 또는 Repository 인터페이스만 알고, 구현체는 알지 못한다.
+RepositoryImpl과 `@Binds` 등록, DataSource, DTO, Mapper 등 데이터 계층 규칙은 [data/README.md](../data/README.md)가 단일 출처다.
+
+## 디렉토리 구조
+
+```
+domain/src/commonMain/kotlin/com/linkit/company/domain/
+├── model/          # 도메인 모델 (data class, enum, sealed class)
+├── repository/     # Repository 인터페이스 (구현체는 data 모듈)
+└── usecase/        # UseCase (생성 기준을 만족하는 경우에만)
+```
+
+## 도메인 모델 작성 규칙
+
+`model/` 패키지에 비즈니스 개념을 표현하는 순수 Kotlin 타입으로 작성한다.
+
+```kotlin
+// model/Link.kt
+data class Link(
+    val id: Long,
+    val title: String,
+    val url: String,
+    val memo: String,
+) {
+    val hasMemo: Boolean get() = memo.isNotEmpty()
+}
+```
+
+- 파일명은 비즈니스 개념 이름 그대로 (`Link.kt`, `LinkStatus.kt`)
+- **도메인 관점의 파생 값·판단 로직은 모델의 프로퍼티/함수로 허용한다** (`hasMemo`, 상태 기반 가능 여부 판단 등). 단, UI 관점의 파생 로직(표시용 포맷팅, 라벨 문자열, 색상 결정 등)은 모델에 두지 않는다 — feature 계층의 책임
+- `enum`, `sealed class`도 비즈니스 개념이면 함께 둔다. 파일이 늘어나면 `model/enum` 등 하위 패키지로 분리 가능
+- **서버 스키마가 아닌 비즈니스 개념 기준으로 설계한다** — 서버 스펙에만 존재하는 필드는 포함하지 않는다
+- nullable 정리, 기본값 처리는 data 모듈의 Mapper에서 끝내고 여기서는 깨끗한 non-null 모델을 지향한다
+- `@Serializable` 등 직렬화 어노테이션을 붙이지 않는다 — 직렬화가 필요한 건 DTO(data)의 사정이다
+
+## Repository 인터페이스 작성 규칙
+
+`repository/` 패키지에 데이터 접근의 **계약(인터페이스)** 만 작성한다.
+
+```kotlin
+// repository/LinkRepository.kt
+interface LinkRepository {
+    suspend fun getLinks(): List<Link>
+    suspend fun createLink(title: String, url: String, memo: String?): Link
+    suspend fun deleteLink(id: Long)
+}
+```
+
+- 이름은 `XxxRepository`
+- 반환 타입은 **도메인 모델 또는 원시값**만 — DTO/Entity가 시그니처에 나타나면 안 된다
+- 요청 데이터는 개별 파라미터로 받는다 (Request DTO 금지)
+- 구현체(`XxxRepositoryImpl`)와 `RepositoryGraph` `@Binds` 등록은 data 모듈에서 한다 — [data/README.md](../data/README.md#repository-작성-규칙) 참고
+
+### suspend vs Flow 선택 기준
+
+| 상황 | 시그니처 |
+| --- | --- |
+| 일회성 조회, 생성·수정·삭제 커맨드 | `suspend fun getLinks(): List<Link>` |
+| 데이터 변화의 지속 구독 (로컬 저장소 관찰 등) | `fun observeLinks(): Flow<List<Link>>` |
+
+- `Flow`를 반환하는 함수에는 `suspend`를 붙이지 않는다 — 구독 시작 자체는 비차단이다
+- 관찰 함수는 `observeXxx` 네이밍으로 일회성 조회(`getXxx`)와 구분한다
+- 현재는 원격 API만 있으므로 `suspend`가 기본이다. 로컬 저장소(Room KMP 등) 도입 시 화면이 변화를 계속 반영해야 하는 데이터부터 `Flow`를 적용한다
+
+## UseCase 생성·생략 기준
+
+비즈니스 규칙이 존재하면 UseCase로 분리한다. ViewModel이 Repository를 직접 호출하는 것은 아래 조건을 **모두** 만족하는 단순 조회로 한정한다.
+
+| 조건 | 설명 |
+| --- | --- |
+| 단일 API | 화면에 필요한 데이터를 Repository 호출 하나로 모두 받는다 |
+| 단순 표시 | 응답 데이터를 그대로(또는 단순 변환만) 화면에 보여준다 |
+| 재사용 없음 | 여러 화면에서 공통으로 재사용할 행위가 아니다 |
+| 비즈니스 규칙 없음 | 정렬·필터링·권한 판단·상태 전이 등 어떤 비즈니스 판단도 없다 |
+
+```
+위 조건 4가지를 모두 만족하는가?
+    YES → ViewModel이 Repository 직접 호출
+    NO  → UseCase 작성 (domain/usecase)
+```
+
+하나라도 만족하지 않으면 UseCase를 작성하며, 비즈니스 규칙은 종류와 무관하게 ViewModel에 두지 않는다. 아래는 참고용 예시로, 목록에 없는 비즈니스 규칙도 UseCase로 분리한다.
+
+| 예시 유형 | 구체적 예 |
+| --- | --- |
+| 여러 Repository 조합 | 링크 목록 + 사용자 설정을 합쳐 화면 데이터 구성 |
+| 정렬·필터링 | 고정 링크 → 최신순으로 정렬 |
+| 권한 판단 | 로그인 상태에 따라 기능 노출 여부 결정 |
+| 상태 전이 | 영상 분석이 완료 상태일 때만 일정 생성 가능 판단 |
+| 여러 화면에서 재사용하는 행위 | 링크 저장 처리를 탐색·보관함·상세 세 곳에서 공통 사용 |
+
+## UseCase 작성 규칙
+
+`usecase/` 패키지에 클래스로 작성한다.
+
+```kotlin
+// usecase/GetSortedLinksUseCase.kt
+@Inject
+class GetSortedLinksUseCase(
+    private val linkRepository: LinkRepository,
+) {
+    suspend operator fun invoke(): List<Link> {
+        return linkRepository.getLinks()
+            .sortedByDescending { it.id }
+    }
+}
+```
+
+- 이름은 행위 동사로 시작하는 `XxxUseCase` (`GetSortedLinksUseCase`, `SaveLinkUseCase`)
+- public 함수는 `operator fun invoke(...)` **하나만** 둔다
+- Repository **인터페이스**만 주입받는다 — 실제 구현체는 data 모듈에 있고 Metro가 런타임에 바인딩한다
+- **다른 UseCase 주입을 허용한다** — 여러 화면에서 재사용하는 행위를 조합할 때 로직을 복사하지 않고 주입으로 해결한다. 단, UseCase 간 순환 의존은 금지
+- Metro `@Inject`로 생성자 주입을 활성화한다. 인터페이스 없는 구체 클래스이므로 별도 `@Binds` 등록은 필요 없다 — ViewModel 생성자에 그대로 주입하면 된다. Metro 에러 발생 시 [docs/METRO_INSTRUCTION.md](../docs/METRO_INSTRUCTION.md) 참고
+
+## 디스패처 규칙 — 메인 세이프 계약
+
+**모든 suspend 함수는 메인 세이프해야 한다** — 어떤 디스패처에서 호출해도 안전하도록 작성한다.
+
+| 계층 | 규칙 |
+| --- | --- |
+| ViewModel (feature) | 디스패처 지정 없이 `viewModelScope`에서 그대로 호출한다. `Dispatchers.IO` 일괄 지정 금지 |
+| UseCase (domain) | 기본적으로 전환하지 않는다. 대량 정렬·파싱 등 **CPU 집약 연산이 실측으로 확인될 때만** `withContext(Dispatchers.Default)`로 한정 |
+| Repository·DataSource (data) | IO 바운드 작업의 스레드 처리는 data 계층의 책임. 단, 아래 이유로 실제 전환 코드는 거의 필요 없다 |
+
+Ktor, Room 등 suspend 기반 라이브러리는 **자체적으로 메인 세이프**하다 — 메인 스레드에서 호출해도 내부에서 IO 처리를 알아서 하므로, 관성적인 `withContext(Dispatchers.IO)` 래핑을 하지 않는다. `Dispatchers.IO` 전환은 블로킹 API(파일 I/O 등)를 suspend 함수로 감쌀 때만 사용하며, 이는 data 계층에서 한다.
+
+## 새 도메인 기능 추가 절차
+
+가상의 `Link` 도메인 기준:
+
+1. **도메인 모델 작성** — `model/Link.kt`
+2. **Repository 인터페이스 작성** — `repository/LinkRepository.kt`
+3. **데이터 계층 구현** — DTO, Mapper, DataSource, RepositoryImpl과 그래프 등록은 [data/README.md — 새 API 추가 절차](../data/README.md#새-api-추가-절차) 참고
+4. **UseCase 작성 여부 판단** — [생성·생략 기준](#usecase-생성생략-기준)에 따라 필요한 경우에만 `usecase/`에 추가
+5. **ViewModel에서 사용** — UseCase 또는 Repository 인터페이스를 생성자 주입
+
+## 금지 규칙 (안티패턴)
+
+| 금지 사항 | 이유 |
+| --- | --- |
+| domain이 data, feature, core:ui, core:designsystem에 의존 | domain은 최하위 계층. 의존 방향은 [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md#의존성-규칙)가 단일 출처 |
+| Android SDK·Compose·Ktor 타입 사용 | 순수 Kotlin 유지. 플랫폼 상세는 data/feature의 책임 |
+| Repository 인터페이스 시그니처에 DTO/Entity 노출 | 데이터 계층 구현 상세가 도메인으로 유출됨. 도메인 모델·원시값만 사용 |
+| UseCase가 UiState·SideEffect·navigation을 의존 | domain은 UI 레이어를 알아서는 안 됨. MVI 타입은 feature/core:common의 소관 |
+| ViewModel 안에 비즈니스 규칙 작성 | 재사용·테스트 불가. UseCase로 분리 |
+| UseCase에 public 함수 여러 개 | 하나의 UseCase는 하나의 행위. `invoke` 하나로 제한 |
+| 단순 조회에 관성적으로 UseCase 생성 | Repository 위임만 하는 빈 껍데기 UseCase는 계층만 늘림. [생성·생략 기준](#usecase-생성생략-기준) 참고 |
+| UI 관점의 파생 로직을 도메인 모델에 배치 | 표시용 포맷팅·라벨·색상 결정은 feature 계층의 책임. 모델에는 도메인 관점의 판단만 허용 |
+| UseCase에서 관성적 `withContext(Dispatchers.IO)` 래핑 | Ktor·Room suspend API는 자체 메인 세이프. [디스패처 규칙](#디스패처-규칙--메인-세이프-계약) 참고 |
+| Mapper를 domain 모듈에 배치 | domain이 data(DTO)에 역의존하게 됨 — 규칙 상세는 [data/README.md](../data/README.md#mapper-작성-규칙-dto--domain-모델)가 단일 출처 |
+
+## 의존성 추가 가이드
+
+- 현재 의존은 `core:common` 하나뿐이며, 이 상태를 유지하는 것을 지향한다
+- 라이브러리 추가는 순수 Kotlin/KMP common 라이브러리(coroutines, kotlinx-datetime 등)로 제한한다
+- Android 전용·UI·네트워크 라이브러리는 이 모듈에 추가하지 않는다 — 각각 feature/data 모듈의 소관


### PR DESCRIPTION
### What is this PR (Required)
- **Issue Number** : closes #36
- 기타 관련 문서 : [data/README.md](../blob/chore/%2336-data_module_readme/data/README.md), [domain/README.md](../blob/chore/%2336-data_module_readme/domain/README.md)

### Changes (Required)
- **`data/README.md` 신규 작성** — 클린아키텍처 data 계층의 구현 규칙 문서화
  - 레이어 흐름, Ktorfit API·DTO·Mapper·DataSource·Repository 작성 규칙
  - 서버 공통 응답 구조 (성공/실패 바디 차이, 2xx 코드별 의미, 에러 코드, Idempotency-Key)
  - 새 API 추가 절차 10단계 (iOS `IosAppGraph` 수동 등록 포함), 금지 규칙(안티패턴) 표
- **`domain/README.md` 신규 작성** — domain 계층의 구현 규칙 문서화 ([Team-MINO core:domain 문서](https://github.com/mash-up-kr/Team-MINO-Android/tree/develop/core/domain) 레퍼런스, KMP + Metro 구조로 재구성)
  - 도메인 모델 규칙 (도메인 관점 파생 로직 허용, UI 관점 파생 로직 금지)
  - Repository 인터페이스 규칙, suspend vs Flow 선택 기준
  - **UseCase 생성·생략 기준** — ViewModel의 Repository 직접 호출 허용 4조건 + 판단 흐름
  - **디스패처 규칙 (메인 세이프 계약)** — 계층별 디스패처 책임, 관성적 `withContext(Dispatchers.IO)` 래핑 금지
- **Sample 코드 네이밍 정리**
  - As-Is: `SampleDataSource` / `SampleDataSourceImpl` (출처 접미사 없음)
  - To-Be: `SampleRemoteDataSource` / `SampleRemoteDataSourceImpl` — 문서의 "출처(`Remote`/`Local`) 접미사 필수" 규칙에 맞춰 rename, 참조 3곳(`DataSourceGraph`, `SampleRepositoryImpl`, `IosAppGraph`) 갱신
- **CLAUDE.md·AGENTS.md** 참고 문서 섹션에 두 README 등록 (읽어야 할 상황 명시)

### Review Point (Required)
- **UseCase 생성·생략 기준 4조건**이 우리 팀 기준으로 적절한지 (단일 API·단순 표시·재사용 없음·비즈니스 규칙 없음)
- **디스패처 메인 세이프 계약** — Ktor/Room이 자체 메인 세이프하므로 관성적 IO 래핑을 금지하는 방향인데, 팀 합의와 맞는지
- **새 API 추가 절차 10단계 (iOS 수동 등록)** — Kotlin 2.2.20 제약 하에서 절차가 실제와 일치하는지
- 두 README와 ARCHITECTURE.md 간 **단일 출처(cross-reference) 구조**가 자연스러운지

### Test Plan (Required)
- 문서 중심 변경으로 런타임 동작 변경 없음
- rename 잔존 참조 grep 검증 (`SampleDataSource` 0건), 문서 내 앵커 링크 전수 검증
- `:data`·`:app-shared` Android 타겟 컴파일로 rename 반영 코드 빌드 확인 (iOS 타겟은 본 변경과 무관한 기존 metrox-viewmodel klib ABI 호환 문제로 로컬 빌드 불가)

### 관련 Reference 자료 (Optional)
- [Team-MINO-Android core:domain README](https://github.com/mash-up-kr/Team-MINO-Android/tree/develop/core/domain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
